### PR TITLE
Update: `infra/docker/php/Dockerfile`

### DIFF
--- a/infra/docker/php/Dockerfile
+++ b/infra/docker/php/Dockerfile
@@ -45,6 +45,8 @@ COPY ./src /var/www/html
 
 RUN composer install -q -n --no-ansi --no-dev --no-scripts --no-progress --prefer-dist \
   && composer dump-autoload \
+  && php artisan config:clear \
+  && php artisan config:cache \
   && chmod -R 777 storage bootstrap/cache \
   && php artisan optimize:clear \
   && php artisan optimize


### PR DESCRIPTION
- fargate上で実行時にenvファイルが読み込まれないためimageビルド時にキャッシュ再作成させる